### PR TITLE
Resolved index param bug

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -82,7 +82,7 @@ struct HttpResponse echo(char** params){
 	char body_buffer[1024];
 	int offset = 0;
 
-	for(int i = 1; params[i] != NULL; i++){
+	for(int i = 0; params[i] != NULL; i++){
 		offset += snprintf(body_buffer, sizeof(body_buffer), "%s\n", params[i]);
 	}
 

--- a/src/route/route.c
+++ b/src/route/route.c
@@ -68,6 +68,8 @@ struct TrieNode* search_route(struct TrieNode *root, char *path, char **params){
 	char* segments[SEGMENTS_MAX];
 	int segCounter = split_string(path, "/", segments);
 
+	int paramsCount = 0;
+
 	struct TrieNode* current = root;
 	for(int i = 0; i < segCounter; i++){
 		int found = 0;
@@ -79,9 +81,10 @@ struct TrieNode* search_route(struct TrieNode *root, char *path, char **params){
 				break;
 			}
 			if(current->children[j] && current->children[j]->isDynamic){
-				params[i] = strdup(segments[i]);
+				params[paramsCount] = strdup(segments[i]);
 				current = current->children[j];
 				found = 1;
+				paramsCount++;
 				break;
 			}
 		}


### PR DESCRIPTION
param index starts depending on the route.. like: /echo/h/:123 params 1 will be in 2 index params = [null, null, 123, null, ...] ; /echo/:123 -> params = [null, 123, null, ...]